### PR TITLE
Add setting to disable editing buttons

### DIFF
--- a/inc/embed.php
+++ b/inc/embed.php
@@ -85,6 +85,7 @@ function pdfjs_generator( $incoming_from_handler ) {
 	$zoom              = pdfjs_validate_zoom( $incoming_from_handler['zoom'] );
 	$pagemode          = get_option( 'pdfjs_viewer_pagemode', 'none' );
 	$searchbutton      = get_option( 'pdfjs_search_button', 'on' );
+	$editingbuttons    = get_option( 'pdfjs_editing_buttons', 'on' );
 	$attachment_id     = pdfjs_sanatize_number( $incoming_from_handler['attachment_id'] );
 	$file_url          = sanitize_url( $incoming_from_handler['url'] );
 	$pdfjs_custom_page = false; // DISABLED get_option( 'pdfjs_custom_page', '' );
@@ -95,6 +96,7 @@ function pdfjs_generator( $incoming_from_handler ) {
 	set_transient( 'pdfjs_button_zoom_' . $attachment_id, $zoom );
 	set_transient( 'pdfjs_button_pagemode_' . $attachment_id, $pagemode );
 	set_transient( 'pdfjs_button_searchbutton_' . $attachment_id, $searchbutton );
+	set_transient( 'pdfjs_button_editingbuttons_' . $attachment_id, $editingbuttons );
 
 	// checks to see if the $file_url is encoded, if so, decode it.
 	if ( strpos( $file_url, '%2F' ) ) {
@@ -119,6 +121,12 @@ function pdfjs_generator( $incoming_from_handler ) {
 		$searchbutton = 'false';
 	}
 
+	if ( 'on' === $editingbuttons ) {
+		$editingbuttons = 'true';
+	} else {
+		$editingbuttons = 'false';
+	}
+
 	if ( 'true' === $fullscreen_target ) {
 		$fullscreen_target = 'target="_blank"';
 	} else {
@@ -128,7 +136,7 @@ function pdfjs_generator( $incoming_from_handler ) {
 	$attachment_info = '?file=' . $file_url . '&attachment_id=' . $attachment_id;
 
 	$nonce     = wp_create_nonce( 'pdfjs_full_screen' );
-	$final_url = $viewer_base_url . $attachment_info . '&dButton=' . $download . '&pButton=' . $print . '&oButton=' . $openfile . '&sButton=' . $searchbutton . '&pagemode=' . $pagemode . '&_wpnonce=' . $nonce;
+	$final_url = $viewer_base_url . $attachment_info . '&dButton=' . $download . '&pButton=' . $print . '&oButton=' . $openfile . '&sButton=' . $searchbutton . '&editButtons=' . $editingbuttons . '&pagemode=' . $pagemode . '&_wpnonce=' . $nonce;
 
 	$fullscreen_link = '';
 	if ( 'true' === $fullscreen ) {

--- a/inc/options-page.php
+++ b/inc/options-page.php
@@ -18,6 +18,10 @@ $plugin_settings = array(
 		'name' => 'Show Search Button',
 		'slug' => 'search_button',
 	),
+	'search' => array(
+		'name' => 'Show Editing Buttons',
+		'slug' => 'editing_buttons',
+	),
 
 	'fullscreen' => array(
 		'name' => 'Show Fullscreen Link',
@@ -70,6 +74,7 @@ function pdfjs_register_settings() {
 	register_setting( 'pdfjs_options_group', 'pdfjs_download_button', 'pdfjs_callback' );
 	register_setting( 'pdfjs_options_group', 'pdfjs_print_button', 'pdfjs_callback' );
 	register_setting( 'pdfjs_options_group', 'pdfjs_search_button', 'pdfjs_callback' );
+	register_setting( 'pdfjs_options_group', 'pdfjs_editing_buttons', 'pdfjs_callback' );
 	register_setting( 'pdfjs_options_group', 'pdfjs_fullscreen_link', 'pdfjs_callback' );
 	register_setting( 'pdfjs_options_group', 'pdfjs_fullscreen_link_text', 'pdfjs_callback' );
 	register_setting( 'pdfjs_options_group', 'pdfjs_fullscreen_link_target', 'pdfjs_callback' );
@@ -100,6 +105,7 @@ function pdfjs_options_page() {
 			$download_button      = get_option( 'pdfjs_download_button', 'on' );
 			$print_button         = get_option( 'pdfjs_print_button', 'on' );
 			$search_button        = get_option( 'pdfjs_search_button', 'on' );
+			$editing_buttons        = get_option( 'pdfjs_editing_buttons', 'on' );
 			$fullscreen_link      = get_option( 'pdfjs_fullscreen_link', 'on' );
 			$fullscreen_link_text = get_option( 'pdfjs_fullscreen_link_text', 'View Fullscreen' );
 			$link_target          = get_option( 'pdfjs_fullscreen_link_target', '' );
@@ -126,6 +132,10 @@ function pdfjs_options_page() {
 				<tr>
 					<th scope="row"><label for="pdfjs_search_button"><?php esc_html_e( 'Show Search Button', 'pdfjs-viewer' ); ?> <sup>1</sup></label></th>
 					<td><input type="checkbox" id="pdfjs_search_button" name="pdfjs_search_button" <?php echo $search_button ? 'checked' : ''; ?> /></td>
+				</tr>
+				<tr>
+					<th scope="row"><label for="pdfjs_editing_buttons"><?php esc_html_e( 'Show Editing Buttons', 'pdfjs-viewer' ); ?> <sup>1</sup></label></th>
+					<td><input type="checkbox" id="pdfjs_editing_buttons" name="pdfjs_editing_buttons" <?php echo $editing_buttons ? 'checked' : ''; ?> /></td>
 				</tr>
 				<tr>
 					<th scope="row"><label for="pdfjs_fullscreen_link"><?php esc_html_e( 'Show Fullscreen Link', 'pdfjs-viewer' ); ?></label></th>

--- a/pdfjs/web/viewer.php
+++ b/pdfjs/web/viewer.php
@@ -294,7 +294,7 @@ See https://github.com/adobe-type-tools/cmap-resources
                         <span id="numPages" class="toolbarLabel"></span>
                     </div>
                     <div id="toolbarViewerRight">
-                        <div id="editorModeButtons" class="splitToolbarButton toggled" role="radiogroup">
+                        <div id="editorModeButtons" class="splitToolbarButton toggled" <?php if ($_GET["editButtons"]!=="true") { echo 'style="display:none;"'; } ?> role="radiogroup">
                             <button id="editorHighlight" class="toolbarButton" hidden="true" disabled="disabled" title="Highlight" role="radio" aria-checked="false" aria-controls="editorHighlightParamsToolbar" tabindex="31" data-l10n-id="pdfjs-editor-highlight-button">
                                 <span data-l10n-id="pdfjs-editor-highlight-button-label">Highlight</span>
                             </button>
@@ -309,7 +309,7 @@ See https://github.com/adobe-type-tools/cmap-resources
                             </button>
                         </div>
 
-                        <div id="editorModeSeparator" class="verticalToolbarSeparator"></div>
+                        <div id="editorModeSeparator" class="verticalToolbarSeparator" <?php if ($_GET["editButtons"]!=="true") { echo 'style="display:none;"'; } ?>></div>
 
                         <button id="print" class="toolbarButton hiddenMediumView" <?php if ($_GET["pButton"]!=="true") { echo 'style="display:none;"'; }?> title="Print" tabindex="41" data-l10n-id="pdfjs-print-button">
                             <span data-l10n-id="pdfjs-print-button-label">Print</span>
@@ -319,7 +319,7 @@ See https://github.com/adobe-type-tools/cmap-resources
                             <span data-l10n-id="pdfjs-save-button-label">Save</span>
                         </button>
 
-                        <div class="verticalToolbarSeparator hiddenMediumView"></div>
+                        <div class="verticalToolbarSeparator hiddenMediumView" <?php if ($_GET["pButton"]!=="true" and $_GET["dButton"]!=="true") { echo 'style="display:none;"'; } ?>></div>
 
                         <button id="secondaryToolbarToggle" class="toolbarButton" title="Tools" tabindex="43" data-l10n-id="pdfjs-tools-button" aria-expanded="false" aria-controls="secondaryToolbar">
                             <span data-l10n-id="pdfjs-tools-button-label">Tools</span>


### PR DESCRIPTION
Re: my post on the support forum, https://wordpress.org/support/topic/request-add-additional-toggles/

This is mostly a copy-paste of the code for the other buttons (the search button for the settings, and download/print buttons for the viewer).

I figured that for most sites this toggle should be global; I can't think of many reasons why someone would want to toggle at a block level but I can think of a lot of reasons why someone would want to turn this off for all files (and it was easier to implement). The default is to show the buttons to match the current default.

A small extra is that is removes the separator bars (the `|`) if the relevant section isn't used.

Tested with both the Gutenberg Block & the shortcode. Here's a screenshot with the editing buttons off but the save & print buttons on:

![image](https://github.com/TwisterMc/pdfjs-viewer-shortcode/assets/25327135/6b4e81ab-94e1-454d-989d-0598d4cbe057)

I haven't done PHP in quite a few years; this is fairly simple but please feel free to leave any comments.